### PR TITLE
docs: Draft breaking changes doc for contributors

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -123,6 +123,8 @@ docs:
                   url: /contributor-setup/
                 - title: 'Coding Guidelines'
                   url: /coding-guidelines/
+                - title: "Maintaining Public APIs"
+                  url: /breaking-changes/
                 - title: 'Committing Code to Spartacus'
                   url: /commit-guidelines/
                 - title: 'Type Safety in Spartacus'

--- a/_pages/contributing/breaking-changes.md
+++ b/_pages/contributing/breaking-changes.md
@@ -1,28 +1,32 @@
 ---
-title: Breaking changes (DRAFT)
+title: Maintaining public API (DRAFT)
 ---
+
+## Keeping public API minimal
+
+Keeping enormous API we have stable is very challenging. Always think about bigger consequences of your changes and try to anticipate new problems, when changing library API.
+
+Check generated public API report with previous `develop` report. Make sure only things that you explicitly wanted exported are visible publicly.
 
 ## Avoiding breaking changes
 
 Below is a list of things should avoid doing while working on new features and bug fixes. We try to following semantic versioning and doing that means keeping breaking changes for major releases. This list should make you aware of different ways to introduce breaking changes.
 
 - don't change selector of component/directive/pipe
-- don't change or remove exported classes, functions, constants, interfaces and types in `public_api.ts` file
+- don't change or remove exported classes, functions, constants, interfaces and types in `public_api.ts` file (note: `index.ts` barrels also can bubble up the exports to `public_api.ts`)
 - don't change or remove interface properties
-- don't change or remove public/protected class members
-- don't change or remove existing public functions parameters (also don't change order)
 - don't add new required properties to interfaces and types (only optional with '?')
+- don't change or remove public/protected class members
+- don't change or remove existing public/protected functions parameters (also don't change order)
 - don't add new required parameters to public functions (only optional)
 - don't change function behavior (after change it should return the same output for provided input and dispatch same side effects). Bug fixes might require different function behavior for edge cases.
 - don't change, remove unit tests (you can only change internal implementation details, assertions shouldn't be changed)
 - don't remove anything from Angular modules (imports, providers, declarations, exports)
-- check generated public API report with previous `develop` report. Make sure only things that you explicitly wanted exported are visible publicly.
-- don't remove or update existing values for public enums (only add new values)
+- don't remove, update existing values or change order for exported enums (only add new values)
 - default value for new functions parameters should match function behavior before change
 - any change to class constructor is breaking (`super` calls needs to be updated in classes extending ours)
-- don't change exported class fields to readonly
+- don't change initial values of exported class' fields or change them to readonly
 - don't change or remove translations
+- don't remove or change default configs
 
 If you have any other general rule regarding breaking changes feel free to add it.
-
-Keeping enormous API we have stable is very challenging. Always think about bigger consequences of your changes and try to anticipate new problems, when changing library API.

--- a/_pages/contributing/breaking-changes.md
+++ b/_pages/contributing/breaking-changes.md
@@ -1,0 +1,28 @@
+---
+title: Breaking changes (DRAFT)
+---
+
+## Avoiding breaking changes
+
+Below is a list of things should avoid doing while working on new features and bug fixes. We try to following semantic versioning and doing that means keeping breaking changes for major releases. This list should make you aware of different ways to introduce breaking changes.
+
+- don't change selector of component/directive/pipe
+- don't change or remove exported classes, functions, constants, interfaces and types in `public_api.ts` file
+- don't change or remove interface properties
+- don't change or remove public/protected class members
+- don't change or remove existing public functions parameters (also don't change order)
+- don't add new required properties to interfaces and types (only optional with '?')
+- don't add new required parameters to public functions (only optional)
+- don't change function behavior (after change it should return the same output for provided input and dispatch same side effects). Bug fixes might require different function behavior for edge cases.
+- don't change, remove unit tests (you can only change internal implementation details, assertions shouldn't be changed)
+- don't remove anything from Angular modules (imports, providers, declarations, exports)
+- check generated public API report with previous `develop` report. Make sure only things that you explicitly wanted exported are visible publicly.
+- don't remove or update existing values for public enums (only add new values)
+- default value for new functions parameters should match function behavior before change
+- any change to class constructor is breaking (`super` calls needs to be updated in classes extending ours)
+- don't change exported class fields to readonly
+- don't change or remove translations
+
+If you have any other general rule regarding breaking changes feel free to add it.
+
+Keeping enormous API we have stable is very challenging. Always think about bigger consequences of your changes and try to anticipate new problems, when changing library API.

--- a/_pages/contributing/breaking-changes.md
+++ b/_pages/contributing/breaking-changes.md
@@ -4,27 +4,27 @@ title: Maintaining Public APIs (DRAFT)
 
 ## Keeping Public APIs Minimal
 
-It is a challenge to maintain stability in large APIs. If you are making changes to the API library, consider the broad consequences of your changes, and try to anticipate any issues that might arise. It is also a good idea to check the generated public API report with previous `develop` reports, and to make sure that only the things you explicitly want to export are visible publicly.
+It is a challenge to maintain stability in large APIs. If you are making changes to the API library, consider the broad consequences of your changes, and try to anticipate any issues that might arise. It is also a good idea to check the generated public API report with previous `develop` reports, and to make sure that only the things you explicitly want to export are publicly visible.
 
 ## Avoiding Breaking Changes
 
 We try to following semantic versioning, which means keeping breaking changes for major releases. When working on new features or bug fixes, the following list of guidelines can help you to avoid introducing breaking changes:
 
 - Do not change the selector of the `component` or `directive` or `pipe`.
-- Do not change or remove exported classes, functions, constants, interfaces or types in `public_api.ts`. Also note that `index.ts` barrels can also bubble up exports to `public_api.ts`.
-- don't change or remove interface properties
-- don't add new required properties to interfaces and types (only optional with '?')
-- don't change or remove public/protected class members
-- don't change or remove existing public/protected functions parameters (also don't change order)
-- don't add new required parameters to public functions (only optional)
-- don't change function behavior (after change it should return the same output for provided input and dispatch same side effects). Bug fixes might require different function behavior for edge cases.
-- don't change, remove unit tests (you can only change internal implementation details, assertions shouldn't be changed)
-- don't remove anything from Angular modules (imports, providers, declarations, exports)
-- don't remove, update existing values or change order for exported enums (only add new values)
-- default value for new functions parameters should match function behavior before change
-- any change to class constructor is breaking (`super` calls needs to be updated in classes extending ours)
-- don't change initial values of exported class' fields or change them to readonly
-- don't change or remove translations
-- don't remove or change default configs
+- Do not change or remove exported classes, functions, constants, interfaces or types in `public_api.ts`. Note that `index.ts` barrels can also bubble up exports to `public_api.ts`.
+- Do not change or remove interface properties.
+- Do not add new, required properties to interfaces and types (only optional with '?')
+- Do not change or remove `public` or `protected` class members
+- Do not change or remove existing `public` or `protected` function parameters (also do not change the order)
+- Do not add new, required parameters to public functions (only optional)
+- Do not change function behavior. After a change, the function should return the same output for the same provided input, and should dispatch the same side effects. Bug fixes might require different function behavior for edge cases.
+- Do not change or remove unit tests. You can change internal implementation details, but assertions should not be changed.
+- Do not remove anything from Angular modules, such as imports, providers, declarations, exports, and so on.
+- Do not remove or update existing values, or change the order for exported enums. Only add new values.
+- Do not change the default value for new functions parameters. The default value should match the function behavior from before the change.
+- Do not make any changes to the class constructor. Any change to the class constructor is considered a breaking change (`super` calls needs to be updated in classes extending ours).
+- Do not change the initial values of an exported class's fields, or change them to readonly.
+- Do not change or remove translations.
+- Do not remove or change default configs.
 
-If you have any other general rule regarding breaking changes feel free to add it.
+If you have any other general rule regarding breaking changes, feel free to add it.

--- a/_pages/contributing/breaking-changes.md
+++ b/_pages/contributing/breaking-changes.md
@@ -1,19 +1,17 @@
 ---
-title: Maintaining public API (DRAFT)
+title: Maintaining Public APIs (DRAFT)
 ---
 
-## Keeping public API minimal
+## Keeping Public APIs Minimal
 
-Keeping enormous API we have stable is very challenging. Always think about bigger consequences of your changes and try to anticipate new problems, when changing library API.
+It is a challenge to maintain stability in large APIs. If you are making changes to the API library, consider the broad consequences of your changes, and try to anticipate any issues that might arise. It is also a good idea to check the generated public API report with previous `develop` reports, and to make sure that only the things you explicitly want to export are visible publicly.
 
-Check generated public API report with previous `develop` report. Make sure only things that you explicitly wanted exported are visible publicly.
+## Avoiding Breaking Changes
 
-## Avoiding breaking changes
+We try to following semantic versioning, which means keeping breaking changes for major releases. When working on new features or bug fixes, the following list of guidelines can help you to avoid introducing breaking changes:
 
-Below is a list of things should avoid doing while working on new features and bug fixes. We try to following semantic versioning and doing that means keeping breaking changes for major releases. This list should make you aware of different ways to introduce breaking changes.
-
-- don't change selector of component/directive/pipe
-- don't change or remove exported classes, functions, constants, interfaces and types in `public_api.ts` file (note: `index.ts` barrels also can bubble up the exports to `public_api.ts`)
+- Do not change the selector of the `component` or `directive` or `pipe`.
+- Do not change or remove exported classes, functions, constants, interfaces or types in `public_api.ts`. Also note that `index.ts` barrels can also bubble up exports to `public_api.ts`.
 - don't change or remove interface properties
 - don't add new required properties to interfaces and types (only optional with '?')
 - don't change or remove public/protected class members


### PR DESCRIPTION
This covers guideline for contributors.
New doc should also be created about handling those breaking changes on version updates, general deprecation policy, making @alpha and @beta API access, automatic migrations, etc.

Those things need to be discussed first. After that, we can provide docs for those topics.

Closes #56 