### PR TITLE
missing translationChunksConfig

### DIFF
--- a/_pages/install/building-the-spartacus-storefront-from-libraries.md
+++ b/_pages/install/building-the-spartacus-storefront-from-libraries.md
@@ -161,7 +161,7 @@ To use Spartacus, your new Angular app needs to import Spartacus libraries.
    import { AppComponent } from './app.component';
    
    import { ConfigModule } from '@spartacus/core';
-   import { translations } from '@spartacus/assets';
+   import { translations, translationChunksConfig } from '@spartacus/assets';
    import { B2cStorefrontModule, defaultCmsContentConfig } from '@spartacus/storefront';
    
    @NgModule({


### PR DESCRIPTION
missing import translationChunksConfig in final version sample 
import { translations, translationChunksConfig } from '@spartacus/assets';