### PR TITLE
Adding missing CORS header for Anonymous Consent

### DIFF
--- a/_pages/install/installing-sap-commerce-cloud.md
+++ b/_pages/install/installing-sap-commerce-cloud.md
@@ -177,7 +177,7 @@ To configure CORS settings for OCC REST APIs, add the following to your SAP Comm
 ```
 corsfilter.ycommercewebservices.allowedOrigins=http://localhost:4200 https://localhost:4200
 corsfilter.ycommercewebservices.allowedMethods=GET HEAD OPTIONS PATCH PUT POST DELETE
-corsfilter.ycommercewebservices.allowedHeaders=origin content-type accept authorization cache-control if-none-match
+corsfilter.ycommercewebservices.allowedHeaders=origin content-type accept authorization cache-control if-none-match x-anonymous-consents
 ```
 
 You can add these settings using the Hybris Administration Console. Hover your mouse over the **Platform** tab, click **Configuration**, then update the CORS settings, as shown above.


### PR DESCRIPTION
This header is required by SmartEdit amongst other things to run properly if anonymous consent is enabled.

related to : https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/5866