### PR TITLE
update pre-release info to remove mentions of 1.4

### DIFF
--- a/_pages/home/pre-release-information.md
+++ b/_pages/home/pre-release-information.md
@@ -8,26 +8,16 @@ If you have any questions, use the help channel of our [Slack workspace](https:/
 
 ## 1.5.0-NEXT.2
 
-Hello everyone!
-
-New pre-release NEXT libraries for 1.5 are now available, containing new features.
-
-**Note:** We are finalizing the `1.4.0` final release, which will be available by next week.
-
-The `1.5.0-NEXT.1` release contains the following features:
+The `1.5.0-NEXT.2` release contains the following features:
 
 - [Customer Coupons](https://github.com/SAP/cloud-commerce-spartacus-storefront-docs/blob/develop/_pages/dev/features/customer-coupons.md)
 - [Selective Cart](https://github.com/SAP/cloud-commerce-spartacus-storefront-docs/blob/develop/_pages/dev/features/selective-cart.md)
-- Variants Scope
-- Some bug fixes
+- Support for variants as seen in the Apparel store
+- Bug fixes
+
+For release notes, see [https://github.com/SAP/cloud-commerce-spartacus-storefront/releases](https://github.com/SAP/cloud-commerce-spartacus-storefront/releases).
 
 ## 1.5.0-NEXT.0
-
-Hello everyone!
-
-New pre-release NEXT libraries for 1.5 are now available, containing new features.
-
-**Note:** As of this time, 1.4.0 is still in RC phase. We plan to release 1.4.0 final in the next few weeks.
 
 Release 1.5.0-NEXT.0 contains the following features:
 
@@ -39,30 +29,6 @@ Release 1.5.0-NEXT.0 contains the following features:
 
 - Improvements to Applied Promotions. Promotions now appear in all required locations (in the **Added-to-Cart** modal for example), not just in the cart. Per-product promotions now also appear in the product entry. This work also includes refactoring to accommodate future support for potential promotions.
 
-- Bug fixes. This first NEXT release for 1.5 includes all bug fixes applied to 1.4.0-RC as well.
+- Bug fixes 
 
 For release notes, see [https://github.com/SAP/cloud-commerce-spartacus-storefront/releases](https://github.com/SAP/cloud-commerce-spartacus-storefront/releases).
-
-More features to come for 1.5... Stay tuned!
-
-## 1.4.0-RC.0
-
-Hello everyone! We’re proud to announce publication of the first 1.4 Release Candidate for our Spartacus libraries.
-See release notes here: [https://github.com/SAP/cloud-commerce-spartacus-storefront/releases](https://github.com/SAP/cloud-commerce-spartacus-storefront/releases).
-
-To use the 1.4 RC libraries, specify ^1.4.0-RC.0 for all Spartacus libraries in your `package.json` file ,except Schematics (which is still 1.3.0 at this time). You must also set your feature level in `app.module.ts` to 1.4.
-
-The 1.4 RC contains everything that was in the 1.4 “next” libraries, plus additional new features and improvements:
-
-- [Wish List](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/wish-list/)
-- [Stock Notification](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/stock-notification/)
-- [Notification Preferences](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/notification-preferences/)
-- [Customer Interests](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/customer-interests/)
-- Changes to cart handling (under the hood)
-- [Token Revocation](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/token-revocation/) (supports backend improvement added to 1905.6).
-- Stackable outlets. For more information, see [GitHub Issue 3462](https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/3462)
-- Performance improvements for loading product information
-- Deferred and Above-the-Fold Loading. For more information, see [GitHub Issue 5823](https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/5823)
-- CMS component data loading optimization. For more information, see [GitHub Issue 5845](https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/5845)
-
-**Note:** The Cancellations and Returns feature is also part of 1.4. However, this feature requires updates to OCC REST APIs that are not yet released. The updated APIs are scheduled to be part of the May 2020 release (Release 2005) of SAP Commerce Cloud. Please see official SAP Commerce Cloud release announcements for more information.


### PR DESCRIPTION
update pre-release doc to remove mentions of 1.4, since it's released now